### PR TITLE
ci: add context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,9 @@ workflows:
                   filters:
                       branches:
                           only: main-2
-                  context: CLI_CTC
+                  context:
+                      - CLI_CTC
+                      - AWS
     test-ts-update:
         triggers:
             - schedule:


### PR DESCRIPTION
the new context contains the rotated AWS keys.

Once this is merged, you can delete the 2 AWS environment varialbes on this project.