### PR TITLE
chore: Add issue and pr templates to repo

### DIFF
--- a/.github/bug_report.md
+++ b/.github/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+NOTICE: While GitHub is the preferred channel for reporting issues/feedback, this is not a mechanism for receiving support under any agreement or SLA. If you require immediate assistance, please use official support channels.
+-->
+
+<!--
+FOR BUGS RELATED TO THE SALEFORCE CLI, please use this repository: https://github.com/forcedotcom/cli
+-->
+
+### Summary
+
+_Short summary of what is going on or to provide context_.
+
+### Steps To Reproduce:
+
+1.  This is step 1.
+1.  This is step 2. All steps should start with '1.'
+
+### Expected result
+
+_Describe what should have happened_.
+
+### Actual result
+
+_Describe what actually happened instead_.
+
+### Additional information
+
+_Feel free to attach a screenshot_.
+
+**Salesforce Extension Version in VS Code**:
+
+**SFDX CLI Version**:
+
+**OS and version**:

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+<!--- PR title should follow the pattern: <type>(optional scope): <description>.
+please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
+If this is a feat/fix, add the technical writer as a reviewer to the PR. --->
+
+### What does this PR do?
+
+### What issues does this PR fix or reference?
+#<Insert GitHub Issue>, @<Insert GUS WI>@
+
+### Functionality Before
+<insert gif and/or summary>
+
+### Functionality After
+<insert gif and/or summary>

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,6 @@ If this is a feat/fix, add the technical writer as a reviewer to the PR. --->
 
 ### Functionality After
 <insert gif and/or summary>
+
+### How to Test/Testing Effort 
+<insert gif and/or summary>


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Adds a template to use when adding a PR.
Adds a template for bug reports and feature requests.

### What issues does this PR fix or reference?
No GH Issue, nor Gus Item

### Functionality Before
PRs were not standard.
When entering a bug or feature request, users we unguided.

### Functionality After
Will guide contributors to provide standard information with a PR.
Users will now have a template to follow when creating an issue