### PR TITLE
chore: enable aura template for scratch orgs using b2b or both

### DIFF
--- a/.github/workflows/validatePR.yml
+++ b/.github/workflows/validatePR.yml
@@ -3,8 +3,7 @@ name: pr-validation
 on:
   pull_request:
     types: [opened, reopened, edited]
-    # only applies to PRs that want to merge to main
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   pr-validation:

--- a/config/b2b-project-scratch-def.json
+++ b/config/b2b-project-scratch-def.json
@@ -1,7 +1,7 @@
 {
   "orgName": "Test B2B Company",
   "edition": "Developer",
-  "features": ["Communities", "B2BCommerce", "OrderManagement", "EnableSetPasswordInApi"],
+  "features": ["Communities", "B2BCommerce", "B2BAuraTemplateEnabled", "OrderManagement", "EnableSetPasswordInApi"],
   "settings": {
     "lightningExperienceSettings": {
       "enableS1DesktopEnabled": true

--- a/config/both-project-scratch-def.json
+++ b/config/both-project-scratch-def.json
@@ -4,6 +4,7 @@
   "features": [
     "Communities",
     "B2BCommerce",
+    "B2BAuraTemplateEnabled",
     "B2CCommerceGMV",
     "PersonAccounts",
     "OrderManagement",


### PR DESCRIPTION
@W-11613524@

This PR enables aura templates for scratch orgs that are created with type `b2b` or type `both`. This PR also adds a validation check for a valid work item associated with the PR surrounded by the `@` symbol in either the description or title