### PR TITLE
feature: README updates to more clearly list out dependencies and how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,7 @@ We always recommend using the latest version of these commands, however, you can
 
 #### Plugin Dependencies
 
-1. [commerce-on-lightning-orchestration](https://github.com/forcedotcom/commerce-on-lightning-orchestration) - commerce-orchestration
-    - scratchorgs
-    - install command: `sfdx plugins:install commerce-orchestration`
-2. [sfdx-1commerce-plugin](https://github.com/forcedotcom/sfdx-1commerce-plugin) - 1commerce
-    - API calls for product import and search index
-    - install command: `sfdx plugins:install 1commerce`
-3. [shane-sfdx-plugins](https://github.com/mshanemc/shane-sfdx-plugins) - shane-sfdx-plugins
+1. [shane-sfdx-plugins](https://github.com/mshanemc/shane-sfdx-plugins) - shane-sfdx-plugins
     - public plugin for imports
     - install command: `sfdx plugins:install shane-sfdx-plugins`
 
@@ -66,7 +60,7 @@ $ npm install -g @salesforce/commerce
 $ sfdx COMMAND
 running command...
 $ sfdx (-v|--version|version)
-@salesforce/commerce/244.0.6 darwin-x64 node-v16.16.0
+@salesforce/commerce/244.0.7 darwin-x64 node-v16.16.0
 $ sfdx --help [COMMAND]
 USAGE
   $ sfdx COMMAND
@@ -83,8 +77,6 @@ USAGE
 sfdx plugins:install @salesforce/commerce
 
 # install dependencies
-sfdx plugins:install commerce-orchestration
-sfdx plugins:install 1commerce
 sfdx plugins:install shane-sfdx-plugins
 ```
 
@@ -186,7 +178,7 @@ EXAMPLE
   sfdx commerce:examples:convert -f store-scratch-def.json
 ```
 
-_See code: [src/commands/commerce/examples/convert.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/examples/convert.ts)_
+_See code: [src/commands/commerce/examples/convert.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/examples/convert.ts)_
 
 ## `sfdx commerce:extension:map [-r <string>] [-n <string>] [-i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -221,7 +213,7 @@ EXAMPLES
   sfdx commerce:extension:map --registered-extension-name test-extension-name --store-id test-store-id
 ```
 
-_See code: [src/commands/commerce/extension/map.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/extension/map.ts)_
+_See code: [src/commands/commerce/extension/map.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/extension/map.ts)_
 
 ## `sfdx commerce:extension:points:list [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -248,7 +240,7 @@ EXAMPLE
   sfdx commerce:extension:getEPN
 ```
 
-_See code: [src/commands/commerce/extension/points/list.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/extension/points/list.ts)_
+_See code: [src/commands/commerce/extension/points/list.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/extension/points/list.ts)_
 
 ## `sfdx commerce:extension:register [-r <string>] [-e <string>] [-a <string>] [-m <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -290,7 +282,7 @@ EXAMPLE
   --apex-class-name test-apex-class
 ```
 
-_See code: [src/commands/commerce/extension/register.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/extension/register.ts)_
+_See code: [src/commands/commerce/extension/register.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/extension/register.ts)_
 
 ## `sfdx commerce:extension:unmap [-r <string>] [-n <string>] [-i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -325,7 +317,7 @@ EXAMPLES
   sfdx commerce:extension:unmap --registered-extension-name test-extension-name --store-id test-store-id
 ```
 
-_See code: [src/commands/commerce/extension/unmap.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/extension/unmap.ts)_
+_See code: [src/commands/commerce/extension/unmap.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/extension/unmap.ts)_
 
 ## `sfdx commerce:files:copy [name=value...] --filestocopy <array> --dirstocopy <array> --copysourcepath <string> [-y] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -366,7 +358,7 @@ EXAMPLES
    "dir1,dir2,dir3"
 ```
 
-_See code: [src/commands/commerce/files/copy.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/files/copy.ts)_
+_See code: [src/commands/commerce/files/copy.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/files/copy.ts)_
 
 ## `sfdx commerce:payments:quickstart:setup -n <string> [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -398,7 +390,7 @@ EXAMPLE
   sfdx commerce:payments:quickstart:setup -p Stripe -n 1commerce
 ```
 
-_See code: [src/commands/commerce/payments/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/payments/quickstart/setup.ts)_
+_See code: [src/commands/commerce/payments/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/payments/quickstart/setup.ts)_
 
 ## `sfdx commerce:products:import -n <string> [-c <string>] [-f <filepath>] [-o <string>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -449,7 +441,7 @@ EXAMPLE
   sfdx commerce:products:import --store-name test-store
 ```
 
-_See code: [src/commands/commerce/products/import.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/products/import.ts)_
+_See code: [src/commands/commerce/products/import.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/products/import.ts)_
 
 ## `sfdx commerce:scratchorg:create [-u <string>] [-a <string>] [-t <string>] [-w <number>] [-y] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -489,7 +481,7 @@ EXAMPLE
   sfdx commerce:scratchorg:create --username demo@1commerce.com --targetdevhubusername ceo@mydevhub.com
 ```
 
-_See code: [src/commands/commerce/scratchorg/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/scratchorg/create.ts)_
+_See code: [src/commands/commerce/scratchorg/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/scratchorg/create.ts)_
 
 ## `sfdx commerce:search:start [-n <string> | -i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -520,7 +512,7 @@ EXAMPLE
           // Finds a store and indexes it
 ```
 
-_See code: [src/commands/commerce/search/start.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/search/start.ts)_
+_See code: [src/commands/commerce/search/start.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/search/start.ts)_
 
 ## `sfdx commerce:store:create [name=value...] -n <string> [-t <string>] [-f <filepath>] [-o <string>] [-b <string>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -568,7 +560,7 @@ EXAMPLE
   sfdx commerce:store:create --store-name test-store
 ```
 
-_See code: [src/commands/commerce/store/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/store/create.ts)_
+_See code: [src/commands/commerce/store/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/store/create.ts)_
 
 ## `sfdx commerce:store:display -n <string> [-b <string>] [-p <string>] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -609,7 +601,7 @@ EXAMPLE
   sfdx commerce:store:display --store-name test-store
 ```
 
-_See code: [src/commands/commerce/store/display.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/store/display.ts)_
+_See code: [src/commands/commerce/store/display.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/store/display.ts)_
 
 ## `sfdx commerce:store:open -n <string> [--all] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -648,7 +640,7 @@ EXAMPLES
   sfdx commerce:store:open --all
 ```
 
-_See code: [src/commands/commerce/store/open.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/store/open.ts)_
+_See code: [src/commands/commerce/store/open.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/store/open.ts)_
 
 ## `sfdx commerce:store:quickstart:create [name=value...] -n <string> [-t <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -681,7 +673,7 @@ EXAMPLE
   sfdx commerce:store:quickstart:create --templatename 'b2c-lite-storefront'
 ```
 
-_See code: [src/commands/commerce/store/quickstart/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/store/quickstart/create.ts)_
+_See code: [src/commands/commerce/store/quickstart/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/store/quickstart/create.ts)_
 
 ## `sfdx commerce:store:quickstart:setup [name=value...] -n <string> [-f <filepath>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -722,7 +714,7 @@ EXAMPLE
   sfdx commerce:store:quickstart:setup --definitionfile store-scratch-def.json
 ```
 
-_See code: [src/commands/commerce/store/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.6/src/commands/commerce/store/quickstart/setup.ts)_
+_See code: [src/commands/commerce/store/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.7/src/commands/commerce/store/quickstart/setup.ts)_
 
 <!-- commandsstop -->
 <!-- debugging-your-plugin -->

--- a/README.md
+++ b/README.md
@@ -18,13 +18,22 @@ This plugin is used to create and setup either a B2B or a B2C store with data wi
 
 We always recommend using the latest version of these commands, however, you can install a specific version or tag if needed.
 
-[commerce-on-lightning-orchestration](https://github.com/forcedotcom/commerce-on-lightning-orchestration) - commerce-orchestration
+-   [commerce-on-lightning](https://github.com/forcedotcom/commerce-on-lightning) - @salesforce/commerce <---- THIS PLUGIN
+    -   create stores
+    -   install command: `sfdx plugins:install @salesforce/commerce`
+    -   install specific version:`sfdx plugins:install @salesforce/commerce@242.0.26`
 
--   scratchorgs
+#### Plugin Dependencies
 
-[commerce-on-lightning](https://github.com/forcedotcom/commerce-on-lightning) - @salesforce/commerce <---- THIS PLUGIN
-
--   store
+1. [commerce-on-lightning-orchestration](https://github.com/forcedotcom/commerce-on-lightning-orchestration) - commerce-orchestration
+    - scratchorgs
+    - install command: `sfdx plugins:install commerce-orchestration`
+2. [sfdx-1commerce-plugin](https://github.com/forcedotcom/sfdx-1commerce-plugin) - 1commerce
+    - API calls for product import and search index
+    - install command: `sfdx plugins:install 1commerce`
+3. [shane-sfdx-plugins](https://github.com/mshanemc/shane-sfdx-plugins) - shane-sfdx-plugins
+    - public plugin for imports
+    - install command: `sfdx plugins:install shane-sfdx-plugins`
 
 ==============
 
@@ -72,6 +81,11 @@ USAGE
 
 ```bash
 sfdx plugins:install @salesforce/commerce
+
+# install dependencies
+sfdx plugins:install commerce-orchestration
+sfdx plugins:install 1commerce
+sfdx plugins:install shane-sfdx-plugins
 ```
 
 <!-- installstop -->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/commerce",
-    "version": "244.0.6",
+    "version": "244.0.7",
     "author": "Jonathan Arndt",
     "bugs": "https://github.com/forcedotcom/commerce-on-lightning/issues",
     "dependencies": {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
README updates only, no code. Updated dependency list to include all current dependencies (I hope). We should probably get this updated in our developer docs as well, for example [here](https://developer.salesforce.com/docs/atlas.en-us.238.0.b2b_b2c_comm_dev.meta/b2b_b2c_comm_dev/b2b_b2c_comm_install_plugins.htm).

### What issues does this PR fix or reference?
no issue, just adding dependencies to try and help customers use the tool without errors or a lot of troubleshooting, as is witnessed in issue #64

### Functionality Before
****
Before Update 1:
****
[commerce-on-lightning-orchestration](https://github.com/forcedotcom/commerce-on-lightning-orchestration) - commerce-orchestration

-   scratchorgs

[commerce-on-lightning](https://github.com/forcedotcom/commerce-on-lightning) - @salesforce/commerce <---- THIS PLUGIN

-   store
****
Before Update 2:
****
#### Install

```bash
sfdx plugins:install @salesforce/commerce
```

### Functionality After

****
After Update 1:
****
-   [commerce-on-lightning](https://github.com/forcedotcom/commerce-on-lightning) - @salesforce/commerce <---- THIS PLUGIN
    -   create stores
    -   install command: `sfdx plugins:install @salesforce/commerce`
    -   install specific version:`sfdx plugins:install @salesforce/commerce@242.0.26`

#### Plugin Dependencies

1. [commerce-on-lightning-orchestration](https://github.com/forcedotcom/commerce-on-lightning-orchestration) - commerce-orchestration
    - scratchorgs
    - install command: `sfdx plugins:install commerce-orchestration`
2. [sfdx-1commerce-plugin](https://github.com/forcedotcom/sfdx-1commerce-plugin) - 1commerce
    - API calls for product import and search index
    - install command: `sfdx plugins:install 1commerce`
3. [shane-sfdx-plugins](https://github.com/mshanemc/shane-sfdx-plugins) - shane-sfdx-plugins
    - public plugin for imports
    - install command: `sfdx plugins:install shane-sfdx-plugin

****
After Update 2:
****
#### Install

```bash
sfdx plugins:install @salesforce/commerce

# install dependencies
sfdx plugins:install commerce-orchestration
sfdx plugins:install 1commerce
sfdx plugins:install shane-sfdx-plugins
```

### How to Test/Testing Effort 
n/a
