### PR TITLE
fix: replace B2B aura permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ npm install -g @salesforce/commerce
 $ sfdx COMMAND
 running command...
 $ sfdx (-v|--version|version)
-@salesforce/commerce/244.0.10 darwin-arm64 node-v16.17.1
+@salesforce/commerce/244.0.11 darwin-x64 node-v16.13.2
 $ sfdx --help [COMMAND]
 USAGE
   $ sfdx COMMAND
@@ -179,7 +179,7 @@ EXAMPLE
   sfdx commerce:examples:convert -f store-scratch-def.json
 ```
 
-_See code: [src/commands/commerce/examples/convert.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/examples/convert.ts)_
+_See code: [src/commands/commerce/examples/convert.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/examples/convert.ts)_
 
 ## `sfdx commerce:extension:map [-r <string>] [-n <string>] [-i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -214,7 +214,7 @@ EXAMPLES
   sfdx commerce:extension:map --registered-extension-name test-extension-name --store-id test-store-id
 ```
 
-_See code: [src/commands/commerce/extension/map.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/extension/map.ts)_
+_See code: [src/commands/commerce/extension/map.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/extension/map.ts)_
 
 ## `sfdx commerce:extension:points:list [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -241,7 +241,7 @@ EXAMPLE
   sfdx commerce:extension:getEPN
 ```
 
-_See code: [src/commands/commerce/extension/points/list.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/extension/points/list.ts)_
+_See code: [src/commands/commerce/extension/points/list.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/extension/points/list.ts)_
 
 ## `sfdx commerce:extension:register [-r <string>] [-e <string>] [-a <string>] [-m <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -283,7 +283,7 @@ EXAMPLE
   --apex-class-name test-apex-class
 ```
 
-_See code: [src/commands/commerce/extension/register.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/extension/register.ts)_
+_See code: [src/commands/commerce/extension/register.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/extension/register.ts)_
 
 ## `sfdx commerce:extension:unmap [-r <string>] [-n <string>] [-i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -318,7 +318,7 @@ EXAMPLES
   sfdx commerce:extension:unmap --registered-extension-name test-extension-name --store-id test-store-id
 ```
 
-_See code: [src/commands/commerce/extension/unmap.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/extension/unmap.ts)_
+_See code: [src/commands/commerce/extension/unmap.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/extension/unmap.ts)_
 
 ## `sfdx commerce:files:copy [name=value...] --filestocopy <array> --dirstocopy <array> --copysourcepath <string> [-y] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -359,7 +359,7 @@ EXAMPLES
    "dir1,dir2,dir3"
 ```
 
-_See code: [src/commands/commerce/files/copy.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/files/copy.ts)_
+_See code: [src/commands/commerce/files/copy.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/files/copy.ts)_
 
 ## `sfdx commerce:payments:quickstart:setup -n <string> [-p <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -391,7 +391,7 @@ EXAMPLE
   sfdx commerce:payments:quickstart:setup -p Stripe -n 1commerce
 ```
 
-_See code: [src/commands/commerce/payments/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/payments/quickstart/setup.ts)_
+_See code: [src/commands/commerce/payments/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/payments/quickstart/setup.ts)_
 
 ## `sfdx commerce:products:import -n <string> [-c <string>] [-f <filepath>] [-o <string>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -442,7 +442,7 @@ EXAMPLE
   sfdx commerce:products:import --store-name test-store
 ```
 
-_See code: [src/commands/commerce/products/import.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/products/import.ts)_
+_See code: [src/commands/commerce/products/import.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/products/import.ts)_
 
 ## `sfdx commerce:scratchorg:create [-u <string>] [-a <string>] [-t <string>] [-w <number>] [-y] [-v <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -482,7 +482,7 @@ EXAMPLE
   sfdx commerce:scratchorg:create --username demo@1commerce.com --targetdevhubusername ceo@mydevhub.com
 ```
 
-_See code: [src/commands/commerce/scratchorg/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/scratchorg/create.ts)_
+_See code: [src/commands/commerce/scratchorg/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/scratchorg/create.ts)_
 
 ## `sfdx commerce:search:start [-n <string> | -i <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -513,7 +513,7 @@ EXAMPLE
           // Finds a store and indexes it
 ```
 
-_See code: [src/commands/commerce/search/start.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/search/start.ts)_
+_See code: [src/commands/commerce/search/start.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/search/start.ts)_
 
 ## `sfdx commerce:store:create [name=value...] -n <string> [-t <string>] [-f <filepath>] [-o <string>] [-b <string>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -561,7 +561,7 @@ EXAMPLE
   sfdx commerce:store:create --store-name test-store
 ```
 
-_See code: [src/commands/commerce/store/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/store/create.ts)_
+_See code: [src/commands/commerce/store/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/store/create.ts)_
 
 ## `sfdx commerce:store:display -n <string> [-b <string>] [-p <string>] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -602,7 +602,7 @@ EXAMPLE
   sfdx commerce:store:display --store-name test-store
 ```
 
-_See code: [src/commands/commerce/store/display.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/store/display.ts)_
+_See code: [src/commands/commerce/store/display.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/store/display.ts)_
 
 ## `sfdx commerce:store:open -n <string> [--all] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -641,7 +641,7 @@ EXAMPLES
   sfdx commerce:store:open --all
 ```
 
-_See code: [src/commands/commerce/store/open.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/store/open.ts)_
+_See code: [src/commands/commerce/store/open.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/store/open.ts)_
 
 ## `sfdx commerce:store:quickstart:create [name=value...] -n <string> [-t <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -674,7 +674,7 @@ EXAMPLE
   sfdx commerce:store:quickstart:create --templatename 'b2c-lite-storefront'
 ```
 
-_See code: [src/commands/commerce/store/quickstart/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/store/quickstart/create.ts)_
+_See code: [src/commands/commerce/store/quickstart/create.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/store/quickstart/create.ts)_
 
 ## `sfdx commerce:store:quickstart:setup [name=value...] -n <string> [-f <filepath>] [-y] [-v <string>] [-u <string>] [--apiversion <string>] [--json] [--loglevel trace|debug|info|warn|error|fatal|TRACE|DEBUG|INFO|WARN|ERROR|FATAL]`
 
@@ -715,7 +715,7 @@ EXAMPLE
   sfdx commerce:store:quickstart:setup --definitionfile store-scratch-def.json
 ```
 
-_See code: [src/commands/commerce/store/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.10/src/commands/commerce/store/quickstart/setup.ts)_
+_See code: [src/commands/commerce/store/quickstart/setup.ts](https://github.com/forcedotcom/commerce-on-lightning/blob/v244.0.11/src/commands/commerce/store/quickstart/setup.ts)_
 
 <!-- commandsstop -->
 <!-- debugging-your-plugin -->

--- a/config/b2b-project-scratch-def.json
+++ b/config/b2b-project-scratch-def.json
@@ -1,27 +1,27 @@
 {
-    "orgName": "Test B2B Company",
-    "edition": "Developer",
-    "features": ["Communities", "B2BCommerce", "LegacyB2BAuraTemplate", "OrderManagement", "EnableSetPasswordInApi"],
-    "settings": {
-        "lightningExperienceSettings": {
-            "enableS1DesktopEnabled": true
-        },
-        "experienceBundleSettings": {
-            "enableExperienceBundleMetadata": true
-        },
-        "communitiesSettings": {
-            "enableNetworksEnabled": true
-        },
-        "orderManagementSettings": {
-            "enableOrderManagement": true
-        },
-        "orderSettings": {
-            "enableOrders": true,
-            "enableEnhancedCommerceOrders": true,
-            "enableOptionalPricebook": true
-        },
-        "commerceSettings": {
-            "commerceEnabled": true
-        }
+  "orgName": "Test B2B Company",
+  "edition": "Developer",
+  "features": ["Communities", "B2BCommerce", "LegacyB2BAuraTemplate", "OrderManagement", "EnableSetPasswordInApi"],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "experienceBundleSettings": {
+      "enableExperienceBundleMetadata": true
+    },
+    "communitiesSettings": {
+      "enableNetworksEnabled": true
+    },
+    "orderManagementSettings": {
+      "enableOrderManagement": true
+    },
+    "orderSettings": {
+      "enableOrders": true,
+      "enableEnhancedCommerceOrders": true,
+      "enableOptionalPricebook": true
+    },
+    "commerceSettings": {
+      "commerceEnabled": true
     }
+  }
 }

--- a/config/b2b-project-scratch-def.json
+++ b/config/b2b-project-scratch-def.json
@@ -1,27 +1,27 @@
 {
-  "orgName": "Test B2B Company",
-  "edition": "Developer",
-  "features": ["Communities", "B2BCommerce", "B2BAuraTemplateEnabled", "OrderManagement", "EnableSetPasswordInApi"],
-  "settings": {
-    "lightningExperienceSettings": {
-      "enableS1DesktopEnabled": true
-    },
-    "experienceBundleSettings": {
-      "enableExperienceBundleMetadata": true
-    },
-    "communitiesSettings": {
-      "enableNetworksEnabled": true
-    },
-    "orderManagementSettings": {
-      "enableOrderManagement": true
-    },
-    "orderSettings": {
-      "enableOrders": true,
-      "enableEnhancedCommerceOrders": true,
-      "enableOptionalPricebook": true
-    },
-    "commerceSettings": {
-      "commerceEnabled": true
+    "orgName": "Test B2B Company",
+    "edition": "Developer",
+    "features": ["Communities", "B2BCommerce", "LegacyB2BAuraTemplate", "OrderManagement", "EnableSetPasswordInApi"],
+    "settings": {
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "experienceBundleSettings": {
+            "enableExperienceBundleMetadata": true
+        },
+        "communitiesSettings": {
+            "enableNetworksEnabled": true
+        },
+        "orderManagementSettings": {
+            "enableOrderManagement": true
+        },
+        "orderSettings": {
+            "enableOrders": true,
+            "enableEnhancedCommerceOrders": true,
+            "enableOptionalPricebook": true
+        },
+        "commerceSettings": {
+            "commerceEnabled": true
+        }
     }
-  }
 }

--- a/config/both-project-scratch-def.json
+++ b/config/both-project-scratch-def.json
@@ -1,38 +1,38 @@
 {
-  "orgName": "Test B2B and B2C Company",
-  "edition": "Developer",
-  "features": [
-    "Communities",
-    "B2BCommerce",
-    "B2BAuraTemplateEnabled",
-    "B2CCommerceGMV",
-    "PersonAccounts",
-    "OrderManagement",
-    "EnableSetPasswordInApi"
-  ],
-  "settings": {
-    "lightningExperienceSettings": {
-      "enableS1DesktopEnabled": true
-    },
-    "experienceBundleSettings": {
-      "enableExperienceBundleMetadata": true
-    },
-    "communitiesSettings": {
-      "enableNetworksEnabled": true
-    },
-    "orderManagementSettings": {
-      "enableOrderManagement": true
-    },
-    "orderSettings": {
-      "enableOrders": true,
-      "enableEnhancedCommerceOrders": true,
-      "enableOptionalPricebook": true
-    },
-    "commerceSettings": {
-      "commerceEnabled": true
-    },
-    "languageSettings": {
-      "enableTranslationWorkbench": true
+    "orgName": "Test B2B and B2C Company",
+    "edition": "Developer",
+    "features": [
+        "Communities",
+        "B2BCommerce",
+        "LegacyB2BAuraTemplate",
+        "B2CCommerceGMV",
+        "PersonAccounts",
+        "OrderManagement",
+        "EnableSetPasswordInApi"
+    ],
+    "settings": {
+        "lightningExperienceSettings": {
+            "enableS1DesktopEnabled": true
+        },
+        "experienceBundleSettings": {
+            "enableExperienceBundleMetadata": true
+        },
+        "communitiesSettings": {
+            "enableNetworksEnabled": true
+        },
+        "orderManagementSettings": {
+            "enableOrderManagement": true
+        },
+        "orderSettings": {
+            "enableOrders": true,
+            "enableEnhancedCommerceOrders": true,
+            "enableOptionalPricebook": true
+        },
+        "commerceSettings": {
+            "commerceEnabled": true
+        },
+        "languageSettings": {
+            "enableTranslationWorkbench": true
+        }
     }
-  }
 }

--- a/config/both-project-scratch-def.json
+++ b/config/both-project-scratch-def.json
@@ -1,38 +1,38 @@
 {
-    "orgName": "Test B2B and B2C Company",
-    "edition": "Developer",
-    "features": [
-        "Communities",
-        "B2BCommerce",
-        "LegacyB2BAuraTemplate",
-        "B2CCommerceGMV",
-        "PersonAccounts",
-        "OrderManagement",
-        "EnableSetPasswordInApi"
-    ],
-    "settings": {
-        "lightningExperienceSettings": {
-            "enableS1DesktopEnabled": true
-        },
-        "experienceBundleSettings": {
-            "enableExperienceBundleMetadata": true
-        },
-        "communitiesSettings": {
-            "enableNetworksEnabled": true
-        },
-        "orderManagementSettings": {
-            "enableOrderManagement": true
-        },
-        "orderSettings": {
-            "enableOrders": true,
-            "enableEnhancedCommerceOrders": true,
-            "enableOptionalPricebook": true
-        },
-        "commerceSettings": {
-            "commerceEnabled": true
-        },
-        "languageSettings": {
-            "enableTranslationWorkbench": true
-        }
+  "orgName": "Test B2B and B2C Company",
+  "edition": "Developer",
+  "features": [
+    "Communities",
+    "B2BCommerce",
+    "LegacyB2BAuraTemplate",
+    "B2CCommerceGMV",
+    "PersonAccounts",
+    "OrderManagement",
+    "EnableSetPasswordInApi"
+  ],
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "experienceBundleSettings": {
+      "enableExperienceBundleMetadata": true
+    },
+    "communitiesSettings": {
+      "enableNetworksEnabled": true
+    },
+    "orderManagementSettings": {
+      "enableOrderManagement": true
+    },
+    "orderSettings": {
+      "enableOrders": true,
+      "enableEnhancedCommerceOrders": true,
+      "enableOptionalPricebook": true
+    },
+    "commerceSettings": {
+      "commerceEnabled": true
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
     }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/commerce",
-    "version": "244.0.10",
+    "version": "244.0.11",
     "author": "Jonathan Arndt",
     "bugs": "https://github.com/forcedotcom/commerce-on-lightning/issues",
     "dependencies": {


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

`B2BAuraTemplateEnabled` is being deprecated and being replaced with `LegacyB2BAuraTemplate`

### What issues does this PR fix or reference?
@W-12614115@

### Functionality Before
No functional changes

### Functionality After
No functional changes

### How to Test/Testing Effort 
1. Create a scratch org with type b2b or both
2. Open scratch org in browser and navigate to store creation and check that B2B aura template is an option
