### PR TITLE
@W-13134865@ - new lwr order confirmation email flow

### DIFF
--- a/examples/b2c/checkout/lwr-order-confirmation-email-flow/objects/OrderSummary.object
+++ b/examples/b2c/checkout/lwr-order-confirmation-email-flow/objects/OrderSummary.object
@@ -27,15 +27,6 @@
         <visibleLines>25</visibleLines>
     </fields>
     <fields>
-        <fullName>OCE_Order_Url__c</fullName>
-        <externalId>false</externalId>
-        <label>OCE Summary Url</label>
-        <length>255</length>
-        <required>false</required>
-        <type>Text</type>
-        <unique>false</unique>
-    </fields>
-    <fields>
         <fullName>OCE_Order_Total__c</fullName>
         <externalId>false</externalId>
         <formula>TotalAdjustedProductAmount +  TotalAdjustedDeliveryAmount  +  TotalTaxAmount</formula>

--- a/examples/b2c/checkout/lwr-order-confirmation-email-flow/package.xml
+++ b/examples/b2c/checkout/lwr-order-confirmation-email-flow/package.xml
@@ -4,7 +4,6 @@
         <members>OrderSummary.OCE_Account_First_Name__c</members>
         <members>OrderSummary.OCE_Account_Last_Name__c</members>
         <members>OrderSummary.OCE_Order_Items__c</members>
-        <members>OrderSummary.OCE_Order_Url__c</members>
         <members>OrderSummary.OCE_Order_Total__c</members>
         <members>OrderSummary.OCE_Payment_Method__c</members>
         <members>OrderSummary.OCE_Shipping_Address__c</members>


### PR DESCRIPTION
What does this PR do?
We have utilised the existing order-confirmation-flow module and created a new similar module for LWR sites. This new module will now include an invocable action that returns the Order Status URL that will be passed into the Confirmation Email. This may not work for any Aura sites since they don't have the features that support as LWR sites do.

What issues does this PR fix or reference?
#, @W-13134865@
[W-13134865](https://gus.lightning.force.com/a07EE00001Qa316YAB)

Functionality Before
<insert gif and/or summary>
Screenshot 2023-06-13 at 10 56 32 AM

Functionality After
<insert gif and/or summary>
Screenshot 2023-05-31 at 6 26 39 PM

https://salesforce.quip.com/gqIwA1jti1uS

How to Test/Testing Effort
<insert gif and/or summary>
We can follow these steps mentioned here - https://github.com/forcedotcom/commerce-on-lightning/tree/develop/examples/b2c/checkout/order-confirmation-email-flow.
Now, while setting Field-Level Security for custom fields , we now have to do for new OCE_Order_Url__c as well. Once the Email comes, we need to verify new "view Order status" Link and clicking on it should redirect to respective Store Order Summary Details URL.