### PR TITLE
Updated B2C & B2B Pricing Samples, changed external request from GET to POST to support 2000 cart items

### DIFF
--- a/examples/b2b/checkout/integrations/classes/B2BPricingSample.cls
+++ b/examples/b2b/checkout/integrations/classes/B2BPricingSample.cls
@@ -33,7 +33,7 @@ global with sharing class B2BPricingSample implements sfdc_checkout.CartPriceCal
             }
 
             // Following snippet of code fetches a mocked static json response from getSalesPricesFromStaticResponse.
-            // Another example that demonstrates how to call a live 3rd party HTTP Service to fetch the desired 
+            // Another example that demonstrates how to call a live 3rd party HTTP Service to fetch the desired
             // response is implemented in getSalesPricesFromExternalService method.
             Map<String, Object> salesPricesFromService = null;
             if(useHTTPService) {
@@ -41,7 +41,7 @@ global with sharing class B2BPricingSample implements sfdc_checkout.CartPriceCal
             } else {
                 salesPricesFromService = getSalesPricesFromStaticResponse(salesPricesFromSalesforce.keySet(), Id.valueOf(customerId));
             }
-            
+
             // For each cart item SKU, check that the price from the external service
             // is the same as the sale price in the cart.
             // If that is not true, set the integration status to "Failed".
@@ -107,7 +107,7 @@ global with sharing class B2BPricingSample implements sfdc_checkout.CartPriceCal
         if (skus.isEmpty()) {
             return (Map<String, Object>) JSON.deserializeUntyped('{"error":"Input SKUs list is empty or undefined."}');
         }
-        
+
         String responseJson = '{';
         for(String sku : skus) {
             Double price = 0.00;
@@ -124,18 +124,15 @@ global with sharing class B2BPricingSample implements sfdc_checkout.CartPriceCal
     }
 
     private Map<String, Object> getSalesPricesFromExternalService(Set<String> skus, String customerId) {
+        Integer successfulHttpRequest = 200;
         Http http = new Http();
         HttpRequest request = new HttpRequest();
-        Integer successfulHttpRequest = 200;
-
-        // Encode the product SKUs to avoid any invalid characters in the request URL.
-        Set<String> encodedSkus = new Set<String>();
-        for (String sku : skus) {
-            encodedSkus.add(EncodingUtil.urlEncode(sku, 'UTF-8'));
-        }
-
-        request.setEndpoint(httpHost + '/get-sales-prices?customerId=' + customerId + '&skus=' + JSON.serialize(encodedSkus));
-        request.setMethod('GET');
+        String requestURL = httpHost + '/get-sales-prices';
+        String requestBody = '{"skus":' + JSON.serialize(skus) + '}';
+        request.setEndpoint(requestURL);
+        request.setMethod('POST');
+        request.setHeader('Content-Type', 'application/json');
+        request.setBody(requestBody);
         HttpResponse response = http.send(request);
         // If the request is successful, parse the JSON response.
         // The response includes the sale price for each SKU and looks something like this:

--- a/examples/b2c/checkout/integrations/classes/B2CPricingSample.cls
+++ b/examples/b2c/checkout/integrations/classes/B2CPricingSample.cls
@@ -33,7 +33,7 @@ global class B2CPricingSample implements sfdc_checkout.CartPriceCalculations {
             }
 
             // Following snippet of code fetches a mocked static json response from getSalesPricesFromStaticResponse.
-            // Another example that demonstrates how to call a live 3rd party HTTP Service to fetch the desired 
+            // Another example that demonstrates how to call a live 3rd party HTTP Service to fetch the desired
             // response is implemented in getSalesPricesFromExternalService method.
             Map<String, Object> salesPricesFromService = null;
             if(useHTTPService) {
@@ -41,7 +41,7 @@ global class B2CPricingSample implements sfdc_checkout.CartPriceCalculations {
             } else {
                 salesPricesFromService = getSalesPricesFromStaticResponse(salesPricesFromSalesforce.keySet(), Id.valueOf(customerId));
             }
-            
+
             // For each cart item SKU, check that the price from the external service
             // is the same as the sale price in the cart.
             // If that is not true, set the integration status to "Failed".
@@ -107,7 +107,7 @@ global class B2CPricingSample implements sfdc_checkout.CartPriceCalculations {
         if (skus.isEmpty()) {
             return (Map<String, Object>) JSON.deserializeUntyped('{"error":"Input SKUs list is empty or undefined."}');
         }
-        
+
         String responseJson = '{';
         for(String sku : skus) {
             Double price = 0.00;
@@ -124,18 +124,15 @@ global class B2CPricingSample implements sfdc_checkout.CartPriceCalculations {
     }
 
     private Map<String, Object> getSalesPricesFromExternalService(Set<String> skus, String customerId) {
+        Integer successfulHttpRequest = 200;
         Http http = new Http();
         HttpRequest request = new HttpRequest();
-        Integer successfulHttpRequest = 200;
-
-        // Encode the product SKUs to avoid any invalid characters in the request URL.
-        Set<String> encodedSkus = new Set<String>();
-        for (String sku : skus) {
-            encodedSkus.add(EncodingUtil.urlEncode(sku, 'UTF-8'));
-        }
-
-        request.setEndpoint(httpHost + '/get-sales-prices?customerId=' + customerId + '&skus=' + JSON.serialize(encodedSkus));
-        request.setMethod('GET');
+        String requestURL = httpHost + '/get-sales-prices';
+        String requestBody = '{"skus":' + JSON.serialize(skus) + '}';
+        request.setEndpoint(requestURL);
+        request.setMethod('POST');
+        request.setHeader('Content-Type', 'application/json');
+        request.setBody(requestBody);
         HttpResponse response = http.send(request);
         // If the request is successful, parse the JSON response.
         // The response includes the sale price for each SKU and looks something like this:


### PR DESCRIPTION
@W-13528094 B2CPricingSample apex will not scale
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001SpnP1YAJ/view

### What does this PR do?
Updated B2C & B2B Pricing Samples, changed external request from GET to POST to support 2000 cart items

### What issues does this PR fix or reference?
@W-13528094@

### Functionality Before
<insert gif and/or summary>
Pricing Sample apex class supports GET method

### Functionality After
Pricing Sample apex class supports POST method

### How to Test/Testing Effort 
Deployed local heroku app which supports POST method request for the pricing
See https://github.com/forcedotcom/commerce-heroku-sample-response/pull/2
