### PR TITLE
@W-14138219@  Fixing currency in international stores

### DIFF
--- a/examples/b2c/checkout/integrations/classes/B2CDeliverySample.cls
+++ b/examples/b2c/checkout/integrations/classes/B2CDeliverySample.cls
@@ -144,7 +144,7 @@ global class B2CDeliverySample implements sfdc_checkout.CartShippingCharges {
         Integer idx = Math.mod(Math.abs(Crypto.getRandomInteger()), chars.length());
         randStr += chars.substring(idx, idx+1);
         }
-        return randStr; 
+        return randStr;
     }
 
     private String getShippingOptionsResponse(String siteLanguage) {
@@ -232,10 +232,10 @@ global class B2CDeliverySample implements sfdc_checkout.CartShippingCharges {
         // ReferenceNumber: Reference Number from External Service
         // IsActive: If this Option is Active
         Id productId = getDefaultShippingChargeProduct2Id();
-        //String cartCurrency = [SELECT CurrencyIsoCode FROM WebCart WHERE Id = :webCartId][0].CurrencyIsoCode;
+        String cartCurrency = [SELECT CurrencyIsoCode FROM CartDeliveryGroup WHERE Id = :cartDeliveryGroupId][0].CurrencyIsoCode;
         CartDeliveryGroupMethod cartDeliveryGroupMethod = new CartDeliveryGroupMethod(
             CartDeliveryGroupId = cartDeliveryGroupId,
-            //CurrencyIsoCode = cartCurrency,
+            CurrencyIsoCode = cartCurrency,
             ExternalProvider = shippingOption.getProvider(),
             Name = shippingOption.getName(),
             ShippingFee = shippingOption.getRate(),


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
This Pr fixes the currency in CartDeliveryGroupMethods which gets created
The Currency of the CartDeliveryGroup is used as the currency for the CartDeliveryGroupMethods.

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-14138219@
@W-14138219

### Functionality Before
In the CartDeliveryGroupMethods which were created, the default currency of USD was being inserted. 

### Functionality After
Now in the CartDeliveryGroupMethods which are created, the currency of the CartDeliveryGroup will be inserted

### How to Test/Testing Effort 
This is tested in an international Store where more than one currency is supported
