### PR TITLE
hotfix: Switch to replaceAll

### DIFF
--- a/src/commands/commerce/store/create.ts
+++ b/src/commands/commerce/store/create.ts
@@ -258,7 +258,7 @@ export class StoreCreate extends SfdxCommand {
             (this.varargs['buyerEmail'] as string).indexOf('scratchOrgBuyerUsername.replace') >= 0
         ) {
             let buyerEmail = os.userInfo().username + '+' + (this.flags['buyer-username'] as string);
-            buyerEmail = buyerEmail.replace('@', 'AT') + '@salesforce.com';
+            buyerEmail = buyerEmail.replaceAll('@', 'AT') + '@salesforce.com';
             this.varargs['buyerEmail'] = buyerEmail;
         }
 


### PR DESCRIPTION
Buyer User Email's replace '@' function requires replaceAll instead of replace.

<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?
Fixes the Buyer Email generation in the store create.ts command
### What issues does this PR fix or reference?
#279 

### Functionality Before
replaces only the first instance of @ with AT

### Functionality After
replaces all the instances of @ with AT

### How to Test/Testing Effort 
sfdx commerce:scratchorg:create -u [hitorg1@hit.demo](mailto:hitorg1@hit.demo) -a "hitorg1" -v devhub -w 30 --json
sfdx commerce:store:create -n b2cstore1 -o b2c -b [b2cbuyer1@gmail.com](mailto:b2cbuyer1@gmail.com) -v devhub -u hitorg1