### PR TITLE
<Bug>(Commerce:Extension) Fix extension-unmap-error

### DIFF
--- a/src/commands/commerce/extension/unmap.ts
+++ b/src/commands/commerce/extension/unmap.ts
@@ -68,7 +68,7 @@ export class UnMapExtension extends SfdxCommand {
         ).result.records[0].Name;
         let deletedId: string;
         const existingIds = forceDataSoql(
-            `SELECT DeveloperName,ExternalServiceProviderType FROM RegisteredExternalService WHERE DeveloperName='${extensionName}' AND ExternalServiceProviderType='Extension'`,
+            `SELECT Id FROM RegisteredExternalService WHERE DeveloperName='${extensionName}' AND ExternalServiceProviderType='Extension'`,
             userName,
             this.flags,
             this.logger
@@ -77,9 +77,7 @@ export class UnMapExtension extends SfdxCommand {
             throw new SfdxError(msgs.getMessage('extension.unmap.error', [extensionName, '\n', existingIds.message]));
         }
         for (const record of existingIds.result.records) {
-            const id = (record['ExternalServiceProviderType'] as string)
-                .concat('__' as string)
-                .concat(record['DeveloperName'] as string);
+            const id = record['Id'];
             const deleteId = forceDataSoql(
                 `SELECT Id FROM StoreIntegratedService WHERE Integration='${id}' AND StoreId='${storeid}'`,
                 userName,


### PR DESCRIPTION
<!--- PR title should follow the pattern: <type>(optional scope): <description>.
please refer to the types and format here: https://www.conventionalcommits.org/en/v1.0.0/#summary
If this is a feat/fix, add the technical writer as a reviewer to the PR. --->

### What does this PR do?

extension-unmap-error 

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @<Insert GUS WI>@

@W-15031437@

### Functionality Before
<insert gif and/or summary>

### Functionality After
<insert gif and/or summary>

### How to Test/Testing Effort 
<insert gif and/or summary>

Register: `./bin/run commerce:extension:register --targetusername <targetusername> --apex-class-name PricingDemoService --extension-point-name Commerce_Domain_Pricing_Service --registered-extension-name PricingDemoService`

Map: `./bin/run commerce:extension:map --registered-extension-name PricingDemoService --store-id <storeId> -u <targetusername>`

Unmap: `./bin/run commerce:extension:unmap --registered-extension-name PricingDemoService -u <targetusername> --store-id <storeId>`