### PR TITLE
 @W-17678630 Fix failing store creation by adding missing apiVersion tag

### DIFF
--- a/examples/b2b/lwc/force-app/main/default/lwc/billingAddressSelector/billingAddressSelector.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/billingAddressSelector/billingAddressSelector.js-meta.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="xmlns=http://soap.sforce.com/2006/04/metadata">
     <isExposed>true</isExposed>
+    <apiVersion>52.0</apiVersion>
 </LightningComponentBundle>

--- a/examples/b2b/lwc/force-app/main/default/lwc/cardPaymentMethod/cardPaymentMethod.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/cardPaymentMethod/cardPaymentMethod.js-meta.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="xmlns=http://soap.sforce.com/2006/04/metadata">
     <isExposed>true</isExposed>
+    <apiVersion>52.0</apiVersion>
 </LightningComponentBundle>

--- a/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
@@ -14,5 +14,5 @@
             <property name="selectedAction" label="The selected action" type="String" description="The action selected by the user (NEXT, BACK)" role="outputOnly"/>
         </targetConfig>
     </targetConfigs>
-    <apiVersion>52.0</apiVersion>
+    <apiVersion>52.0</apiVersion> 
 </LightningComponentBundle>

--- a/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
@@ -14,5 +14,5 @@
             <property name="selectedAction" label="The selected action" type="String" description="The action selected by the user (NEXT, BACK)" role="outputOnly"/>
         </targetConfig>
     </targetConfigs>
-    <apiVersion>52.0</apiVersion> 
+    <apiVersion>52.0</apiVersion>
 </LightningComponentBundle>

--- a/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/navigationButtons/navigationButtons.js-meta.xml
@@ -14,4 +14,5 @@
             <property name="selectedAction" label="The selected action" type="String" description="The action selected by the user (NEXT, BACK)" role="outputOnly"/>
         </targetConfig>
     </targetConfigs>
+    <apiVersion>52.0</apiVersion>
 </LightningComponentBundle>

--- a/examples/b2b/lwc/force-app/main/default/lwc/paymentMethod/paymentMethod.js-meta.xml
+++ b/examples/b2b/lwc/force-app/main/default/lwc/paymentMethod/paymentMethod.js-meta.xml
@@ -34,4 +34,5 @@
             <property name="purchaseOrderNumber" label="Purchase Order Number" type="String" description="The entered purchase order number" role="outputOnly" />
         </targetConfig>
     </targetConfigs>
+    <apiVersion>52.0</apiVersion>
 </LightningComponentBundle>


### PR DESCRIPTION
fix: Add apiversion tag as per the failure logs in store creation  

### What does this PR do?
Adding missing tag `apiVersion`

### What issues does this PR fix or reference?
#<Insert GitHub Issue>, @W-17678630@

### Functionality Before

<img width="745" alt="image" src="https://github.com/user-attachments/assets/1fcfc9a3-1429-4b1a-9ab3-9c3cace09e0d" />


B2B LWR Store creation was unsuccessful
B2B Aura Store creation was unsuccessful
 
### Functionality After
B2B LWR Store creation successful
B2B Aura Store creation successful

### How to Test/Testing Effort 

`sf commerce store create -n b2blwr02 -o b2b -b b2blwrbuyer_jenkins@1commerce.com -v ****@****.com -u ****@salesforce.com —apiversion=63.0 —json`
